### PR TITLE
Adding CODE_OF_CONDUCT.adoc (draft version)

### DIFF
--- a/CODE_OF_CONDUCT.adoc
+++ b/CODE_OF_CONDUCT.adoc
@@ -1,0 +1,55 @@
+NOTE: This is a DRAFT version
+
+[[contributor-covenant-code-of-conduct]]
+= *Contributor Covenant Code of Conduct*
+
+[[our-pledge]]
+== Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+[[our-standards]]
+== Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+[[our-responsibilities]]
+== Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+[[scope]]
+== Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
+
+[[enforcement]]
+== Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the moderation team at `<email here>`. The moderation team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances therefore you may not receive a direct response. The moderation team will use their discretion in determining when and how to follow up on reported incidents, which may range from not taking action to permanent expulsion from the project and project-sponsored spaces. The moderation team is obligated to maintain confidentiality with regard to the reporter of an incident.
+
+Contributors who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
+
+[[attribution]]
+== Attribution
+
+This Code of Conduct is adapted from the http://contributor-covenant.org[Contributor Covenant^], version 1.4, available at http://contributor-covenant.org/version/1/4
+
+
+If you have suggestions to improve this code of conduct, please submit an issue or pull request.

--- a/CODE_OF_CONDUCT.adoc
+++ b/CODE_OF_CONDUCT.adoc
@@ -42,7 +42,7 @@ This Code of Conduct applies both within project spaces and in public spaces whe
 [[enforcement]]
 == Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the moderation team at `<email here>`. The moderation team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances therefore you may not receive a direct response. The moderation team will use their discretion in determining when and how to follow up on reported incidents, which may range from not taking action to permanent expulsion from the project and project-sponsored spaces. The moderation team is obligated to maintain confidentiality with regard to the reporter of an incident.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the Steering Group. The Steering Group will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances therefore you may not receive a direct response. The Steering Group will use their discretion in determining when and how to follow up on reported incidents, which may range from not taking action to permanent expulsion from the project and project-sponsored spaces. The Steering Group is obligated to maintain confidentiality with regard to the reporter of an incident.
 
 Contributors who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
 

--- a/CODE_OF_CONDUCT.adoc
+++ b/CODE_OF_CONDUCT.adoc
@@ -1,5 +1,3 @@
-NOTE: This is a DRAFT version
-
 [[contributor-covenant-code-of-conduct]]
 = *Contributor Covenant Code of Conduct*
 

--- a/CODE_OF_CONDUCT.adoc
+++ b/CODE_OF_CONDUCT.adoc
@@ -42,7 +42,7 @@ This Code of Conduct applies both within project spaces and in public spaces whe
 [[enforcement]]
 == Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the Steering Group. The Steering Group will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances therefore you may not receive a direct response. The Steering Group will use their discretion in determining when and how to follow up on reported incidents, which may range from not taking action to permanent expulsion from the project and project-sponsored spaces. The Steering Group is obligated to maintain confidentiality with regard to the reporter of an incident.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project Steering Group at etf-sg@jrc.ec.europa.eu. The Steering Group will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances therefore you may not receive a direct response. The Steering Group will use their discretion in determining when and how to follow up on reported incidents, which may range from not taking action to permanent expulsion from the project and project-sponsored spaces. The Steering Group is obligated to maintain confidentiality with regard to the reporter of an incident.
 
 Contributors who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
 


### PR DESCRIPTION
Adding the draft version of the Code of Conduct in AsciiDoc format.