### PR TITLE
Update initial EIP process steps in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ The governance is ensured through the Steering Group and Technical Committee.
 The current status of ETF Improvement Proposals (EIPs) and bug fixing can be tracked through these project boards:
 
 * [ETF Improvement Proposals (EIPs)](https://github.com/orgs/etf-validator/projects/2)
-  * If you would like to discuss an idea before documenting a full EIP, create an issue, tag is as an "EIP-idea" and add it to "Proposer: draft/refine EIP". Move it to "SG: discussion" when ready for discussion by the Steering Group. If the Steering Group supports it, it will change the tag to "EIP" and move it back to "Proposer: draft/refine EIP". 
-  * Once an EIP is ready for approval, the proposer should move it (again, if it was an idea before) to "SG: discussion". If the draft needs further updates, it will be moved back to "Proposer: draft/refine EIP".
+  * If you would like to discuss an idea before documenting a full EIP, simply create a new issue using the [EIP template](https://github.com/etf-validator/governance/issues/new/choose). Complete the template as far as possible and mention that this is not a complete proposal yet, but that you are looking for feedback. The ETF Steering Group members monitor the issues and will tag is as an "EIP-idea" and add it to "Proposer: draft/refine EIP". The Steering Group will move it to "SG: discussion" when ready for discussion by the Steering Group. If the Steering Group supports it, it will change the tag to "EIP",  move it back to "Proposer: draft/refine EIP" and ask you to complete the proposal.
+  * Once an EIP is ready for approval, please indicate this in a comment to the issue and the Steering Group will move it to "SG: discussion". If the draft needs further updates, it will be moved back to "Proposer: draft/refine EIP" until all open questions are resolved.
 * [Bug fixing](https://github.com/orgs/etf-validator/projects/3)
 
 ## Contributing
 
-If you are interested in contributing to the ETF project, please read carefully the [contribution guidelines](TOR/Contribution.md) and send us your signed ETF Contributor License Agreement.
+If you are interested in contributing to the ETF project, please read carefully the [contribution guidelines](TOR/Contribution.md) and send us your signed ETF Developer Certificate of Origin.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ The governance is ensured through the Steering Group and Technical Committee.
 The current status of ETF Improvement Proposals (EIPs) and bug fixing can be tracked through these project boards:
 
 * [ETF Improvement Proposals (EIPs)](https://github.com/orgs/etf-validator/projects/2)
+  * If you would like to discuss an idea before documenting a full EIP, create an issue, tag is as an "EIP-idea" and add it to "Proposer: draft/refine EIP". Move it to "SG: discussion" when ready for discussion by the Steering Group. If the Steering Group supports it, it will change the tag to "EIP" and move it back to "Proposer: draft/refine EIP". 
+  * Once an EIP is ready for approval, the proposer should move it (again, if it was an idea before) to "SG: discussion". If the draft needs further updates, it will be moved back to "Proposer: draft/refine EIP".
 * [Bug fixing](https://github.com/orgs/etf-validator/projects/3)
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ The current status of ETF Improvement Proposals (EIPs) and bug fixing can be tra
   * If you would like to discuss an idea before documenting a full EIP, simply create a new issue using the [EIP template](https://github.com/etf-validator/governance/issues/new/choose). Complete the template as far as possible and mention that this is not a complete proposal yet, but that you are looking for feedback. The ETF Steering Group members monitor the issues and will tag is as an "EIP-idea" and add it to "Proposer: draft/refine EIP". The Steering Group will move it to "SG: discussion" when ready for discussion by the Steering Group. If the Steering Group supports it, it will change the tag to "EIP",  move it back to "Proposer: draft/refine EIP" and ask you to complete the proposal.
   * Once an EIP is ready for approval, please indicate this in a comment to the issue and the Steering Group will move it to "SG: discussion". If the draft needs further updates, it will be moved back to "Proposer: draft/refine EIP" until all open questions are resolved.
 * [Bug fixing](https://github.com/orgs/etf-validator/projects/3)
+  * If you would like to submit a bug report, please create a new issue in the etf-webapp repository using the [Bug report template](https://github.com/etf-validator/etf-webapp/issues/new/choose). The ETF Technical Committee members monitor the issues and will add them to bugfixing project board. If additional information is required, you will be contacted. Pull requests for bugfixes are very welcome (see "Contributing" below)!
+  * The Technical Committee will update the project board whenever the status of an issue changes.
 
 ## Contributing
 
-If you are interested in contributing to the ETF project, please read carefully the [contribution guidelines](TOR/Contribution.md) and send us your signed ETF Developer Certificate of Origin.
+If you are interested in contributing to the ETF project, please read carefully the [contribution guidelines](TOR/Contribution.md).


### PR DESCRIPTION
Note: The [project board](https://github.com/orgs/etf-validator/projects/2) has been updated as discussed in the [6th SG meeting](https://github.com/etf-validator/governance/blob/master/Meetings/SG/20181106.adoc#eip-workflow). 